### PR TITLE
Postgres should use existing secret

### DIFF
--- a/charts/appflowy/values.yaml
+++ b/charts/appflowy/values.yaml
@@ -178,8 +178,10 @@ postgresql:
   auth:
     username: appflowy
     database: appflowy
-    password: password
-    postgresPassword: password
+    existingSecret: "appflowy"
+    secretKey:
+      adminPasswordKey: postgresAdminPassword
+      userPasswordKey: postgresPassword
   primary:
     persistence:
       enabled: true


### PR DESCRIPTION
In order to achieve a better consistency, the postgres passwords should be re-used from the `appflowy` secret.