### PR TITLE
worker use smtp user

### DIFF
--- a/charts/appflowy/charts/appflowy-worker/templates/deployment.yaml
+++ b/charts/appflowy/charts/appflowy-worker/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
             - name: APPFLOWY_MAILER_SMTP_PORT
               value: {{ .Values.global.smtp.port | quote}}
             - name: APPFLOWY_MAILER_SMTP_USERNAME
-              value: {{ .Values.global.smtp.username }}
+              value: {{ .Values.global.smtp.user }}
             - name: APPFLOWY_MAILER_SMTP_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Currently, the worker is configured to use `.Values.global.smtp.username`, which doesn't exist. This value should be `.Values.global.smtp.user`, which is a supported value documented [here](https://github.com/khorshuheng/appflowy-self-host-resources/blob/a9756a53841a2efce41352617a207ebc406cc2c0/charts/appflowy/README.md?plain=1#L55).